### PR TITLE
Fix SVG bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,13 +27,18 @@ function defaultKey (req, file, cb) {
 }
 
 function autoContentType (req, file, cb) {
-  file.stream.once('data', function (firstChunk) {
-    var type = fileType(firstChunk)
+  var data = ''
+  file.stream.on('data', function(chunk) {
+    data += chunk.toString();
+  })
+  
+  file.stream.once('end', function () {
+    var type = fileType(data)
     var mime
 
     if (type) {
       mime = type.mime
-    } else if (isSvg(firstChunk)) {
+    } else if (isSvg(data)) {
       mime = 'image/svg+xml'
     } else {
       mime = 'application/octet-stream'
@@ -41,7 +46,7 @@ function autoContentType (req, file, cb) {
 
     var outStream = new stream.PassThrough()
 
-    outStream.write(firstChunk)
+    outStream.write(data)
     file.stream.pipe(outStream)
 
     cb(null, mime, outStream)

--- a/index.js
+++ b/index.js
@@ -27,12 +27,14 @@ function defaultKey (req, file, cb) {
 }
 
 function autoContentType (req, file, cb) {
-  var data = ''
+  var buffer = []
+  
   file.stream.on('data', function(chunk) {
-    data += chunk.toString();
+    buffer.push(chunk)
   })
   
   file.stream.once('end', function () {
+    var data = Buffer.concat(buffer)
     var type = fileType(data)
     var mime
 

--- a/index.js
+++ b/index.js
@@ -28,20 +28,24 @@ function defaultKey (req, file, cb) {
 
 function autoContentType (req, file, cb) {
   var buffer = []
-  
-  file.stream.on('data', function(chunk) {
+
+  file.stream.on('data', function (chunk) {
     buffer.push(chunk)
   })
-  
+
+  /**
+   *  While `fileType` only requires the first chunk of the file stream,
+   * `isSvg` requires the entire file to be read, so we must use the `end` event rather than `data`
+   */
   file.stream.once('end', function () {
     var data = Buffer.concat(buffer)
     var type = fileType(data)
     var mime
 
-    if (type) {
-      mime = type.mime
-    } else if (isSvg(data)) {
+    if (isSvg(data)) {
       mime = 'image/svg+xml'
+    } else if (type) {
+      mime = type.mime
     } else {
       mime = 'application/octet-stream'
     }


### PR DESCRIPTION
The bug:

1. `fileType` will detect svg files as `application/xml` before `isSvg` is called.
2. `isSvg` requires the entire file contents to work, while `fileType` only requires the first chunk.

The solution:
1.   isSvg is more specific, so move it above the fileType call.
2. Use the `end` event rather than `data` event for the file stream.